### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,14 @@
+### Describe the bug
+<!-- Clear description of the problem -->
+
+### Steps to Reproduce
+1. 
+2. 
+3. 
+
+### Expected behavior
+<!-- What you expected to happen -->
+
+### Additional context
+<!-- Screenshots, logs, or other info -->
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,8 @@
+### Describe the feature
+<!-- Describe what you want to happen -->
+
+### Motivation
+<!-- Why is this feature useful? -->
+
+### Additional context
+<!-- Screenshots, examples, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+# Summary
+<!-- Briefly describe what this PR does -->
+
+## Rationale
+<!-- Why are these changes needed? -->
+
+## Changes
+<!-- List the main changes made -->
+
+## Impact
+<!-- Describe any impact this PR may have on the project -->
+
+## Testing
+<!-- How did you test these changes? -->
+
+## Screenshots/Video
+<!-- Optional: add screenshots or video -->
+
+## Checklist
+- [ ] Code follows the project's coding standards
+- [ ] Unit tests covering the new feature have been added
+- [ ] All existing tests pass
+- [ ] Documentation has been updated if necessary
+
+## Additional Notes
+<!-- Any extra notes or context -->
+


### PR DESCRIPTION
# Summary
This PR adds standardized templates for issues and pull requests to guide contributors and maintain consistency across the repository.

## Rationale
Having templates ensures that all contributors provide the necessary information when opening issues or PRs. This improves communication, reduces back-and-forth questions, and keeps the project organized.

## Changes
- Added `.github/ISSUE_TEMPLATE/bug_report.md` for reporting bugs
- Added `.github/ISSUE_TEMPLATE/feature_request.md` for requesting new features
- Added `.github/PULL_REQUEST_TEMPLATE.md` to structure pull request descriptions

## Impact
- No impact on existing code or gameplay features
- Only affects how issues and PRs are created in the repository

## Testing
- Verified that opening a new issue presents the correct template options
- Verified that opening a new PR automatically loads the PR template

## Screenshots/Video
- Not applicable

## Checklist
- [x] Templates are in the correct `.github/` directory
- [x] Templates render correctly in GitHub
- [x] Documentation is up-to-date (if necessary)

## Additional Notes
- These templates can be expanded in the future to include other types of issues or PR workflows
